### PR TITLE
fix header image disppearing when clicked

### DIFF
--- a/layout/styles/layout.css
+++ b/layout/styles/layout.css
@@ -734,7 +734,7 @@ a {
 }
 
 a:active, a:focus {
-  background: transparent;
+  background-color: transparent;
 }
 
 /* IE10 + 11 Bugfix - prevents grey background */


### PR DESCRIPTION
I noticed that when clicking the banner image it will disappear until another area of the page is clicked. Not sure if there is a more ideal solution, but my change seems to fix it.