### PR TITLE
Add .sidenav-close to contact item in side nav

### DIFF
--- a/activities.html
+++ b/activities.html
@@ -39,7 +39,7 @@
         <li><a class="black-text" href="#inv">INVENTORY</a></li>
         <li><a class="black-text" href="activities.html">ACTIVITIES</a></li>
         <li><a class="black-text" href="team.html">TEAM</a></li>
-        <li><a class="black-text" href="#contact">CONTACT</a></li>
+        <li><a class="black-text sidenav-close" href="#contact">CONTACT</a></li>
       </ul>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       <li><a class="black-text" href="#inv">INVENTORY</a></li>
       <li><a class="black-text" href="activities.html">ACTIVITIES</a></li>
       <li><a class="black-text" href="team.html">TEAM</a></li>
-      <li><a class="black-text" href="#contact">CONTACT</a></li>
+      <li><a class="black-text sidenav-close" href="#contact">CONTACT</a></li>
     </ul>
 
     <!-- particles.js container -->

--- a/team.html
+++ b/team.html
@@ -40,7 +40,7 @@
       <li><a class="black-text" href="#inv">INVENTORY</a></li>
       <li><a class="black-text" href="activities.html">ACTIVITIES</a></li>
       <li><a class="black-text" href="#home">TEAM</a></li>
-      <li><a class="black-text" href="#contact">CONTACT</a></li>
+      <li><a class="black-text sidenav-close" href="#contact">CONTACT</a></li>
     </ul>
 
     <!-- particles.js container -->

--- a/template.html
+++ b/template.html
@@ -39,7 +39,7 @@
         <li><a class="black-text" href="#inv">INVENTORY</a></li>
         <li><a class="black-text" href="activities.html">ACTIVITIES</a></li>
         <li><a class="black-text" href="team.html">TEAM</a></li>
-        <li><a class="black-text" href="#contact">CONTACT</a></li>
+        <li><a class="black-text sidenav-close" href="#contact">CONTACT</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
Fixes #49.

I found [this](https://materializecss.com/sidenav.html#close-trigger) in the Materialize documentation, it solves the problem of closing the side nav when the contact item is clicked. I added this fix to index.html, activities.html, team.html, and template.html.

However, I don't know what is causing the page to jump to the top when the side nav is opened so it still does that but the issue is technically fixed.