### PR TITLE
Fixed Media Path

### DIFF
--- a/src/stac_iitmandi/templates/stac_iitmandi/utkarsh.html
+++ b/src/stac_iitmandi/templates/stac_iitmandi/utkarsh.html
@@ -4,8 +4,6 @@
 
 <div class="bg-image utkarsh-logo header-pad banner-img" style="color: #FFFF;">
     <img src="{% static 'stac_iitmandi/images/utkarsh.png' %}" alt="Utkarsh-logo">
-    <br>
-    <hr class="titlehr" />
 </div>
 
 <div class="section-bg title-box">

--- a/src/web_main/settings.py
+++ b/src/web_main/settings.py
@@ -24,10 +24,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 try:
     import secret
     SECRET_KEY = secret.SECRET_KEY
-    DEBUG = True
 except ImportError:
     SECRET_KEY = os.environ.get("SECRET_KEY")
-    DEBUG = True
+
+DEBUG = False
 
 ALLOWED_HOSTS = ['stac.iitmandi.co.in', '127.0.0.1', 'localhost']
 
@@ -129,8 +129,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = "/static/"
-STATIC_ROOT = os.path.join(str(BASE_DIR), 'static')
+STATIC_ROOT = os.path.join(str(BASE_DIR), 'static/')
 
-MEDIA_ROOT = os.path.join(str(BASE_DIR), "stac_iitmandi/static/stac_iitmandi/images/")
+MEDIA_ROOT = os.path.join(str(BASE_DIR), "static/stac_iitmandi/images/")
 
-MEDIA_URL = "/stac_iitmandi/static/stac_iitmandi/images/"
+MEDIA_URL = "/static/stac_iitmandi/images/"

--- a/src/web_main/urls.py
+++ b/src/web_main/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path("", include("stac_iitmandi.urls")),
 ]
 
-urlpatterns += static( # only works in DEBUG mode
+urlpatterns += static(  # only works in DEBUG mode
     settings.MEDIA_URL,
     document_root=settings.MEDIA_ROOT
 )

--- a/src/web_main/urls.py
+++ b/src/web_main/urls.py
@@ -8,8 +8,7 @@ urlpatterns = [
     path("", include("stac_iitmandi.urls")),
 ]
 
-if settings.DEBUG:
-    urlpatterns += static(
-        settings.MEDIA_URL,
-        document_root=settings.MEDIA_ROOT
-    )
+urlpatterns += static( # only works in DEBUG mode
+    settings.MEDIA_URL,
+    document_root=settings.MEDIA_ROOT
+)

--- a/src/web_main/wsgi.py
+++ b/src/web_main/wsgi.py
@@ -13,7 +13,9 @@ import sys
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "web_main.settings")
-sys.path.append('~/STAC-IITMandi.github.io/src/') # path/src
-sys.path.append('~/STAC-IITMandi.github.io/src/web_main') # path/src/web_main
+
+# Tested on Apache. Add appropriate path before apache service.
+sys.path.append('~/STAC-IITMandi.github.io/src/')  # path/src
+sys.path.append('~/STAC-IITMandi.github.io/src/web_main')  # path/src/web_main
 
 application = get_wsgi_application()

--- a/src/web_main/wsgi.py
+++ b/src/web_main/wsgi.py
@@ -8,9 +8,12 @@ https://docs.djangoproject.com/en/3.1/howto/deployment/wsgi/
 """
 
 import os
+import sys
 
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "web_main.settings")
+sys.path.append('~/STAC-IITMandi.github.io/src/') # path/src
+sys.path.append('~/STAC-IITMandi.github.io/src/web_main') # path/src/web_main
 
 application = get_wsgi_application()


### PR DESCRIPTION
## Description

Django can't serve static path when debugging is off. Therefore we use service like Apache which serves the static files. I fixed the static files path, so we can turn off the debugging

## How Has This Been Tested?
Live on website right now.